### PR TITLE
Enable for a much more generic implementation

### DIFF
--- a/capistrano-getservers.gemspec
+++ b/capistrano-getservers.gemspec
@@ -5,11 +5,11 @@ require 'capistrano-getservers/get_servers'
 
 Gem::Specification.new do |gem|
   gem.name          = "capistrano-getservers"
-  gem.version       = '1.0.4'
-  gem.authors       = ["Alfred Moreno"]
-  gem.email         = ["alfred.moreno@zumba.com"]
-  gem.description   = %q{A capistrano plugin for simplifying EC2 deployment processes}
-  gem.summary       = %q{A capistrano plugin for simplifying EC@ deployment processes}
+  gem.version       = '2.0.1'
+  gem.authors       = ["Alfred Moreno",'David Collom']
+  gem.email         = ["alfred.moreno@zumba.com",'david@collom.co.uk']
+  gem.description   = %q{A capistrano plugin for simplifying FOG deployment processes}
+  gem.summary       = %q{A capistrano plugin for simplifying FOG deployment processes}
   gem.homepage      = ""
 
   gem.files         = `git ls-files`.split($/)

--- a/lib/capistrano-getservers/get_servers.rb
+++ b/lib/capistrano-getservers/get_servers.rb
@@ -8,49 +8,40 @@ end
 module Capistrano
   class Configuration
     module GetServers
+
       #############################################################
       # def get_servers
       #
-      # Purpose: Retrieves a list of EC2 instances containing a tag
-      #          list which matches a supplied hash.
+      # Purpose: Retrieves a list of instances matching when the
+      #          block yields true
       #
       #          Matching instances are applied to the Cap server
       #          list.
       #
-      # Usage: get_servers {'app' => 'zumba', 'stack' => 'web'}
+      # Usage: get_servers(:app) {|inst| inst.name =~ /^www\./}
       #
       # Returns: Nothing
       #############################################################
-      def get_servers(role=nil, region=nil, cli_tags)
-
-        ec2 = Fog::Compute::AWS.new(
-          aws_secret_access_key: ENV['AWS_SECRET_ACCESS_KEY'],
-          aws_access_key_id: ENV['AWS_ACCESS_KEY_ID'],
-          region: region
-        )
-
-        ec2.servers.all.each do |instance|
+      def get_servers(role=nil)
+        fog_servers.each do |instance|
           begin
-            instance_tags = instance.tags.reject { |k,v| cli_tags[k] != instance.tags[k] }
-            server (instance.public_ip_address || instance.private_ip_address), (role || :web) if instance_tags.eql?(cli_tags)
+            if yield(instance)
+              puts "# #{role}: #{instance.name} [#{(instance.public_ip_address || instance.private_ip_address)}]"
+              server (instance.public_ip_address || instance.private_ip_address), (role || :web)
+            end
           rescue => error
+            puts "[ERROR] #{error.message}"
           end
         end
 
       end
 
-      #############################################################
-      # def parse
-      #
-      # Purpose: Parses a string object and returns a hash.
-      #
-      # Usage: parse 'k1:v1,k2:v2,k3:v3'
-      #
-      # Returns: {'k1' => 'v1', 'k2' => 'v2', 'k3' => 'v3'}
-      #############################################################
-      def parse tags
-        return unless tags.class.eql? String
-        tags.split(',').each.inject({}) { |hash, pair| hash.merge! Hash[*pair.split(':').flatten] }
+      def fog_servers
+        @fog_servers ||= (fog_service.servers.all || [])
+      end
+
+      def fog_service
+        @fog_service ||= ::Fog::Compute.new(fog_settings)
       end
 
     end


### PR DESCRIPTION
First of all, can I thank you for your original code, it was a great help for me to implement what I was aiming for with a dynamic deployment solution.

However I am currently using rackspace which doesn't support tagging of server instances. 

I have updated your code to enable users to pass a specific block of code, when returned true will include the server within capistrano's server list. 

I have also updated the readme.md to reflect the API changes and examples.

I l'd like to hear what your thoughts are regarding this? and/or if you would like my to implement this differently?

_This pull request breaks the existing API but I feel as though this is a much more generic implementation_
