### PR TITLE
support for either string matching or regex matching of server names

### DIFF
--- a/lib/capistrano-getservers/get_servers.rb
+++ b/lib/capistrano-getservers/get_servers.rb
@@ -43,7 +43,7 @@ module Capistrano
               )
 
               rackspace.servers.select do |rackspace_server|
-                if cli_tags.include?(rackspace_server.name)
+                if cli_tags.include?(rackspace_server.name) || rackspace_server.name =~ Regexp.new(cli_tags)
                   server (rackspace_server.ipv4_address || rackspace_server.addresses['private']['addr']), (role || :web)
                 end
               end


### PR DESCRIPTION
We use the format of www1-<project>.<domain>.. which could be problematic with the current implementation. however this code allows for a much more fine grained control with Regular expression support
