### PR TITLE
use the variables for AWS access credentials rather than the ENV variabl...

### DIFF
--- a/lib/capistrano-getservers/get_servers.rb
+++ b/lib/capistrano-getservers/get_servers.rb
@@ -50,8 +50,8 @@ module Capistrano
 
             else
               ec2 = Fog::Compute::AWS.new(
-                aws_secret_access_key: ENV['AWS_SECRET_ACCESS_KEY'],
-                aws_access_key_id: ENV['AWS_ACCESS_KEY_ID'],
+                aws_secret_access_key: fetch(:aws_secret_access_key),
+                aws_access_key_id: fetch(:aws_access_key_id),
                 region: region
               )
 


### PR DESCRIPTION
allows the user to set the aws credentials in the deploy.rb file as such:
set :aws_access_key_id, "XXXXXXXXXXXXXXXXXXXXXXX"
set :aws_secret_access_key, "XXXXXXXXXXXXxXXXXXXXXXXXXX"
